### PR TITLE
fix(header): single-open menus, outside-click close, dashboard logo to landing, lang chevron

### DIFF
--- a/src/components/common/LanguageSwitcher.tsx
+++ b/src/components/common/LanguageSwitcher.tsx
@@ -1,25 +1,37 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Check, Globe } from 'lucide-react';
+import { Check, ChevronDown, Globe } from 'lucide-react';
 import { useLangStore } from '@/store/useStore';
 import { useT } from '@/lib/i18n';
 
 export default function LanguageSwitcher() {
   const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
   const lang = useLangStore((s: any) => s.lang);
   const setLang = useLangStore((s: any) => s.setLang);
   const t = useT();
 
+  // Ferme le menu au clic en dehors.
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', onDown);
+    return () => document.removeEventListener('mousedown', onDown);
+  }, [open]);
+
   return (
-    <div className="relative">
+    <div ref={ref} className="relative">
       <button
         onClick={() => setOpen((v) => !v)}
         className="flex items-center gap-1.5 text-sm font-medium px-2.5 py-1.5 rounded-lg text-gray-400 hover:text-white hover:bg-white/5 transition-colors"
       >
         <Globe size={14} />
         <span>{lang === 'fr' ? 'FR' : 'EN'}</span>
+        <ChevronDown size={14} className={`transition-transform ${open ? 'rotate-180' : ''}`} />
       </button>
       <AnimatePresence>
         {open && (

--- a/src/components/landing/LandingHeader.tsx
+++ b/src/components/landing/LandingHeader.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
@@ -27,11 +27,13 @@ const SECTIONS = [
   { key: 'nav.contact', id: 'contact', icon: Mail },
 ];
 
+type OpenMenu = 'lang' | 'profile' | 'sections' | null;
+
 export default function LandingHeader() {
-  const [menuOpen, setMenuOpen] = useState(false);
-  const [langOpen, setLangOpen] = useState(false);
+  // Un seul menu ouvert à la fois (exclusion mutuelle).
+  const [openMenu, setOpenMenu] = useState<OpenMenu>(null);
   const [signInOpen, setSignInOpen] = useState(false);
-  const [profileOpen, setProfileOpen] = useState(false);
+  const navRef = useRef<HTMLDivElement>(null);
   const lang = useLangStore((s: any) => s.lang);
   const setLang = useLangStore((s: any) => s.setLang);
   const userProfile = useAuthStore((s: any) => s.userProfile);
@@ -59,16 +61,30 @@ export default function LandingHeader() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Ferme tout menu ouvert quand on clique en dehors de la zone de navigation.
+  useEffect(() => {
+    if (!openMenu) return;
+    const onDown = (e: MouseEvent) => {
+      if (navRef.current && !navRef.current.contains(e.target as Node)) setOpenMenu(null);
+    };
+    document.addEventListener('mousedown', onDown);
+    return () => document.removeEventListener('mousedown', onDown);
+  }, [openMenu]);
+
+  // Ouvre un menu en fermant l'éventuel autre (bascule si déjà ouvert).
+  const toggle = (menu: Exclude<OpenMenu, null>) =>
+    setOpenMenu((cur) => (cur === menu ? null : menu));
+
   const logout = () => {
     setToken(null);
     setUser(null);
     setUserProfile(null);
-    setProfileOpen(false);
+    setOpenMenu(null);
   };
 
   // Défilement fluide vers une section de la page (ou le haut si id vide).
   const goTo = (id: string) => {
-    setMenuOpen(false);
+    setOpenMenu(null);
     if (!id) {
       window.scrollTo({ top: 0, behavior: 'smooth' });
       return;
@@ -86,11 +102,11 @@ export default function LandingHeader() {
         </Link>
 
         {/* Droite */}
-        <div className="flex items-center gap-3 sm:gap-4">
+        <div ref={navRef} className="flex items-center gap-3 sm:gap-4">
           {/* Sélecteur de langue */}
           <div className="relative">
             <button
-              onClick={() => setLangOpen((v) => !v)}
+              onClick={() => toggle('lang')}
               className="flex items-center gap-1.5 text-white/80 hover:text-white transition-colors"
               aria-label="Langue"
             >
@@ -99,7 +115,7 @@ export default function LandingHeader() {
               <ChevronDown size={14} />
             </button>
             <AnimatePresence>
-              {langOpen && (
+              {openMenu === 'lang' && (
                 <motion.div
                   initial={{ opacity: 0, y: -8, scale: 0.96 }}
                   animate={{ opacity: 1, y: 0, scale: 1 }}
@@ -111,7 +127,7 @@ export default function LandingHeader() {
                       key={l.code}
                       onClick={() => {
                         setLang(l.code);
-                        setLangOpen(false);
+                        setOpenMenu(null);
                       }}
                       className={`w-full flex items-center justify-between px-4 py-2.5 text-sm transition-colors ${
                         lang === l.code
@@ -132,7 +148,7 @@ export default function LandingHeader() {
           {userProfile ? (
             <div className="relative">
               <button
-                onClick={() => setProfileOpen((v) => !v)}
+                onClick={() => toggle('profile')}
                 className="flex items-center gap-2 p-1 rounded-lg hover:bg-white/10 transition-colors"
                 aria-label="Profil"
               >
@@ -153,7 +169,7 @@ export default function LandingHeader() {
               </button>
 
               <AnimatePresence>
-                {profileOpen && (
+                {openMenu === 'profile' && (
                   <motion.div
                     initial={{ opacity: 0, y: -8, scale: 0.96 }}
                     animate={{ opacity: 1, y: 0, scale: 1 }}
@@ -168,7 +184,7 @@ export default function LandingHeader() {
                     </div>
                     <Link
                       href="/dashboard"
-                      onClick={() => setProfileOpen(false)}
+                      onClick={() => setOpenMenu(null)}
                       className="w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-gray-300 hover:bg-gaming-surface hover:text-white transition-colors"
                     >
                       <LayoutDashboard size={16} /> {t('header.dashboard')}
@@ -196,15 +212,15 @@ export default function LandingHeader() {
           {/* Menu */}
           <div className="relative">
             <button
-              onClick={() => setMenuOpen((v) => !v)}
+              onClick={() => toggle('sections')}
               aria-label="Menu"
               className="p-2 rounded-lg text-white/80 hover:text-white hover:bg-white/10 transition-colors"
             >
-              {menuOpen ? <X size={22} /> : <Menu size={22} />}
+              {openMenu === 'sections' ? <X size={22} /> : <Menu size={22} />}
             </button>
 
             <AnimatePresence>
-              {menuOpen && (
+              {openMenu === 'sections' && (
                 <motion.div
                   initial={{ opacity: 0, y: -8, scale: 0.96 }}
                   animate={{ opacity: 1, y: 0, scale: 1 }}

--- a/src/components/layout/DashboardHeader.tsx
+++ b/src/components/layout/DashboardHeader.tsx
@@ -42,7 +42,8 @@ export default function DashboardHeader() {
       <div className="h-full max-w-7xl mx-auto px-4 sm:px-6 flex items-center justify-between">
         {/* Logo + navigation */}
         <div className="flex items-center gap-8">
-          <Link href="/dashboard" className="flex items-center">
+          {/* Le logo ramène à la landing page. */}
+          <Link href="/" className="flex items-center">
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img src="/mlbb-togo-logo.png" alt="MLBB Togo" className="h-9 w-auto" />
           </Link>


### PR DESCRIPTION
## Corrections du header

- **Menus mutuellement exclusifs** : sur le header de la landing, ouvrir un menu (langue / profil / sections) ferme automatiquement l'autre. Fini le chevauchement.
- **Fermeture au clic extérieur** : cliquer ailleurs sur la page ferme le menu ouvert (landing + sélecteur de langue du dashboard).
- **Logo du dashboard → landing** : cliquer sur le logo MLBB Togo dans le dashboard ramène à la page d'accueil.
- **Chevron sur le sélecteur de langue du dashboard** : ajoute la flèche descendante (cohérence avec la landing), qui pivote à l'ouverture.

Typecheck OK.