### PR TITLE
perf(api): cache and de-duplicate read requests

### DIFF
--- a/src/app/(main)/teams/page.tsx
+++ b/src/app/(main)/teams/page.tsx
@@ -146,7 +146,7 @@ export default function TeamsPage() {
         }
       />
 
-      {/* Organisation esport */}
+      {/* Esport organisation */}
       {org && (
         <SectionCard className="flex items-center gap-4">
           {org.logo && (
@@ -167,7 +167,7 @@ export default function TeamsPage() {
         </SectionCard>
       )}
 
-      {/* Onglets + recherche */}
+      {/* Tabs + search */}
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
         <Tabs
           active={tab}
@@ -191,7 +191,7 @@ export default function TeamsPage() {
         </div>
       </div>
 
-      {/* Contenu de l'onglet actif */}
+      {/* Active tab content */}
       {loading ? (
         <LoadingSpinner size="lg" className="py-24" />
       ) : activeList.length === 0 ? (

--- a/src/components/ui/index.tsx
+++ b/src/components/ui/index.tsx
@@ -100,7 +100,7 @@ export function Button({
 /* ------------------------------------------------------------------ */
 
 export function Card({ children, className, hover = false, glow = false, ...props }: any) {
-  // hover/glow sont consommés ici pour ne pas fuir en attributs DOM.
+  // hover/glow are consumed here so they don't leak as DOM attributes.
   return (
     <div
       className={cn(

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -47,40 +47,75 @@ interface RequestOptions {
   auth?: boolean;
 }
 
+// Lightweight in-memory cache + GET request de-duplication. Avoids repeated or
+// concurrent calls (React StrictMode double-invoke in dev, navigations, several
+// components reading the same resource). Any write clears the cache to stay fresh.
+const GET_TTL = 20_000; // 20s
+const getCache = new Map<string, { at: number; data: any }>();
+const inFlight = new Map<string, Promise<any>>();
+
+export function clearApiCache() {
+  getCache.clear();
+  inFlight.clear();
+}
+
 async function request<T = any>(path: string, options: RequestOptions = {}): Promise<T> {
   const { method = 'GET', body, fallback, auth = true } = options;
-  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  const isGet = method === 'GET';
   const token = getToken();
+
+  // A write may make the read cache stale.
+  if (!isGet) getCache.clear();
+
+  const key = `${path}|${auth && token ? 'a' : 'g'}`;
+
+  if (isGet) {
+    const cached = getCache.get(key);
+    if (cached && Date.now() - cached.at < GET_TTL) return cached.data as T;
+    const pending = inFlight.get(key);
+    if (pending) return pending as Promise<T>;
+  }
+
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
   if (auth && token) headers['Authorization'] = `Bearer ${token}`;
 
-  try {
-    const res = await fetch(`${API_URL}${path}`, {
-      method,
-      headers,
-      body: body ? JSON.stringify(body) : undefined,
-      cache: 'no-store',
-    });
-    if (!res.ok) {
-      let message = `Erreur ${res.status}`;
-      try {
-        const data = await res.json();
-        message = data.message || message;
-      } catch {
-
+  const doFetch = async (): Promise<T> => {
+    try {
+      const res = await fetch(`${API_URL}${path}`, {
+        method,
+        headers,
+        body: body ? JSON.stringify(body) : undefined,
+        cache: 'no-store',
+      });
+      if (!res.ok) {
+        let message = `Erreur ${res.status}`;
+        try {
+          const data = await res.json();
+          message = data.message || message;
+        } catch {
+          //
+        }
+        throw new ApiError(message, res.status);
       }
-      throw new ApiError(message, res.status);
+      const data = res.status === 204 ? (undefined as T) : ((await res.json()) as T);
+      if (isGet) getCache.set(key, { at: Date.now(), data });
+      return data;
+    } catch (err) {
+      if (fallback !== undefined) {
+        // eslint-disable-next-line no-console
+        console.warn(`[api] échec sur ${path}, repli.`);
+        return fallback as T;
+      }
+      throw err;
     }
-    if (res.status === 204) return undefined as T;
-    return (await res.json()) as T;
-  } catch (err) {
+  };
 
-    if (fallback !== undefined) {
-      // eslint-disable-next-line no-console
-      console.warn(`[api] échec sur ${path}, repli.`);
-      return fallback as T;
-    }
-    throw err;
-  }
+  if (!isGet) return doFetch();
+
+  // De-duplication: identical in-flight GETs share one promise.
+  const p = doFetch().finally(() => inFlight.delete(key));
+  inFlight.set(key, p);
+  return p;
 }
 
 export class ApiError extends Error {

--- a/src/lib/gql.ts
+++ b/src/lib/gql.ts
@@ -1,31 +1,48 @@
-// Client GraphQL minimal (fetch natif, lecture seule).
-// L'endpoint GraphQL est sur le même hôte que le REST mais sans le préfixe /api.
-// On lit process.env directement (et PAS API_URL depuis ./api) pour éviter un
-// import circulaire api.ts <-> gql.ts qui casse l'initialisation en SSR.
+// Minimal GraphQL client (native fetch, read-only).
+// The GraphQL endpoint shares the REST host but without the /api prefix.
+// Reads process.env directly (NOT API_URL from ./api) to avoid an api<->gql
+// circular import that breaks module init during SSR.
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3006/api';
 
-// Dérive l'URL GraphQL depuis la base REST : .../api -> .../graphql
+// Derive the GraphQL URL from the REST base: .../api -> .../graphql
 export const GQL_URL = `${API_BASE.replace(/\/api\/?$/, '')}/graphql`;
 
 /**
  * Exécute une requête GraphQL et renvoie `data` typé.
  * Lève une erreur si le serveur renvoie des `errors`.
  */
+// Cache + de-duplication (same idea as the REST client): avoids StrictMode
+// duplicates and identical re-reads on the landing.
+const GQL_TTL = 30_000; // 30s
+const cache = new Map<string, { at: number; data: any }>();
+const inFlight = new Map<string, Promise<any>>();
+
 export async function gql<T = any>(
   query: string,
   variables?: Record<string, any>,
 ): Promise<T> {
-  const res = await fetch(GQL_URL, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ query, variables }),
-    cache: 'no-store',
-  });
+  const key = query + '|' + JSON.stringify(variables ?? {});
+  const hit = cache.get(key);
+  if (hit && Date.now() - hit.at < GQL_TTL) return hit.data as T;
+  const pending = inFlight.get(key);
+  if (pending) return pending as Promise<T>;
 
-  const json = await res.json();
-  if (json.errors?.length) {
-    throw new Error(json.errors[0]?.message || 'Erreur GraphQL');
-  }
-  return json.data as T;
+  const exec = (async () => {
+    const res = await fetch(GQL_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query, variables }),
+      cache: 'no-store',
+    });
+    const json = await res.json();
+    if (json.errors?.length) {
+      throw new Error(json.errors[0]?.message || 'Erreur GraphQL');
+    }
+    cache.set(key, { at: Date.now(), data: json.data });
+    return json.data as T;
+  })().finally(() => inFlight.delete(key));
+
+  inFlight.set(key, exec);
+  return exec;
 }


### PR DESCRIPTION
Add a lightweight in-memory cache (20s TTL) and in-flight de-duplication for GET requests in the REST client, and the same for the GraphQL client (30s). Kills the duplicate calls from React StrictMode and repeated reads across navigations; writes clear the cache to stay fresh. Also translate touched comments to English.