### PR TITLE
fix(modal): portal + scroll lock so overlays cover the full page

### DIFF
--- a/src/components/landing/SignInModal.tsx
+++ b/src/components/landing/SignInModal.tsx
@@ -8,6 +8,7 @@ import { api, setToken } from '@/lib/api';
 import { useAuthStore } from '@/store/useStore';
 import { useT } from '@/lib/i18n';
 import { Button, Input } from '@/components/ui';
+import Portal from '@/components/ui/Portal';
 import toast from 'react-hot-toast';
 
 export default function SignInModal({ open, onClose }: { open: boolean; onClose: () => void }) {
@@ -42,6 +43,15 @@ export default function SignInModal({ open, onClose }: { open: boolean; onClose:
     const id = setTimeout(() => setCooldown((c) => c - 1), 1000);
     return () => clearTimeout(id);
   }, [cooldown]);
+
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
 
   const handle = (k: string) => (e: any) => setForm((f) => ({ ...f, [k]: e.target.value.replace(/[^0-9]/g, '') }));
 
@@ -123,22 +133,23 @@ export default function SignInModal({ open, onClose }: { open: boolean; onClose:
   };
 
   return (
-    <AnimatePresence>
-      {open && (
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          onClick={onClose}
-          className="fixed inset-0 z-[60] flex items-center justify-center p-4 bg-black/70 backdrop-blur-sm"
-        >
+    <Portal>
+      <AnimatePresence>
+        {open && (
           <motion.div
-            initial={{ opacity: 0, scale: 0.94, y: 12 }}
-            animate={{ opacity: 1, scale: 1, y: 0 }}
-            exit={{ opacity: 0, scale: 0.94, y: 12 }}
-            onClick={(e) => e.stopPropagation()}
-            className="relative w-full max-w-md rounded-2xl border border-gaming-border bg-gaming-card p-7 sm:p-8 shadow-2xl"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            onClick={onClose}
+            className="fixed inset-0 z-[60] flex items-center justify-center p-4 bg-black/70 backdrop-blur-sm overflow-y-auto"
           >
+            <motion.div
+              initial={{ opacity: 0, scale: 0.94, y: 12 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.94, y: 12 }}
+              onClick={(e) => e.stopPropagation()}
+              className="relative w-full max-w-md max-h-[90vh] overflow-y-auto rounded-2xl border border-gaming-border bg-gaming-card p-7 sm:p-8 shadow-2xl"
+            >
             <button
               onClick={onClose}
               aria-label="Fermer"
@@ -217,7 +228,8 @@ export default function SignInModal({ open, onClose }: { open: boolean; onClose:
             )}
           </motion.div>
         </motion.div>
-      )}
-    </AnimatePresence>
+        )}
+      </AnimatePresence>
+    </Portal>
   );
 }

--- a/src/components/profile/LinkGameModal.tsx
+++ b/src/components/profile/LinkGameModal.tsx
@@ -7,6 +7,7 @@ import { api } from '@/lib/api';
 import { useAuthStore } from '@/store/useStore';
 import toast from 'react-hot-toast';
 import { useT } from '@/lib/i18n';
+import Portal from '@/components/ui/Portal';
 
 export default function LinkGameModal({
   open,
@@ -33,6 +34,15 @@ export default function LinkGameModal({
     const id = setTimeout(() => setCooldown((c) => c - 1), 1000);
     return () => clearTimeout(id);
   }, [cooldown]);
+
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
 
   const handle = (k: string) => (e: any) =>
     setForm((f) => ({ ...f, [k]: e.target.value.replace(/[^0-9]/g, '') }));
@@ -79,22 +89,23 @@ export default function LinkGameModal({
   };
 
   return (
-    <AnimatePresence>
-      {open && (
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          onClick={onClose}
-          className="fixed inset-0 z-[60] flex items-center justify-center p-4 bg-black/70 backdrop-blur-sm"
-        >
+    <Portal>
+      <AnimatePresence>
+        {open && (
           <motion.div
-            initial={{ opacity: 0, scale: 0.94, y: 12 }}
-            animate={{ opacity: 1, scale: 1, y: 0 }}
-            exit={{ opacity: 0, scale: 0.94, y: 12 }}
-            onClick={(e) => e.stopPropagation()}
-            className="relative w-full max-w-md rounded-2xl border border-[#1e3f66] bg-gradient-to-b from-[#0c2038] to-[#0a1626] p-7 sm:p-8 shadow-2xl"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            onClick={onClose}
+            className="fixed inset-0 z-[60] flex items-center justify-center p-4 bg-black/70 backdrop-blur-sm overflow-y-auto"
           >
+            <motion.div
+              initial={{ opacity: 0, scale: 0.94, y: 12 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.94, y: 12 }}
+              onClick={(e) => e.stopPropagation()}
+              className="relative w-full max-w-md max-h-[90vh] overflow-y-auto rounded-2xl border border-[#1e3f66] bg-gradient-to-b from-[#0c2038] to-[#0a1626] p-7 sm:p-8 shadow-2xl"
+            >
             <button
               onClick={onClose}
                aria-label={t('linkGame.close')}
@@ -159,7 +170,8 @@ export default function LinkGameModal({
             </form>
           </motion.div>
         </motion.div>
-      )}
-    </AnimatePresence>
+        )}
+      </AnimatePresence>
+    </Portal>
   );
 }

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,8 +1,10 @@
 'use client';
 
+import { useEffect } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { X } from 'lucide-react';
 import { cn } from '@/lib/helpers';
+import Portal from './Portal';
 
 const SIZE_MAP: Record<string, string> = {
   sm: 'max-w-md',
@@ -42,16 +44,27 @@ export default function Modal({
   const width = maxWidth || SIZE_MAP[size];
   const gradient = headerVariant === 'gradient';
 
+  // Lock body scroll while open so the background doesn't scroll behind.
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
   return (
-    <AnimatePresence>
-      {open && (
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          onClick={onClose}
-          className="fixed inset-0 z-[60] flex items-center justify-center p-4 bg-black/70 backdrop-blur-sm"
-        >
+    <Portal>
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            onClick={onClose}
+            className="fixed inset-0 z-[60] flex items-center justify-center p-4 bg-black/70 backdrop-blur-sm overflow-y-auto"
+          >
           <motion.div
             initial={{ opacity: 0, scale: 0.96, y: 10 }}
             animate={{ opacity: 1, scale: 1, y: 0 }}
@@ -117,7 +130,8 @@ export default function Modal({
             <div className="p-5 overflow-y-auto">{children}</div>
           </motion.div>
         </motion.div>
-      )}
-    </AnimatePresence>
+        )}
+      </AnimatePresence>
+    </Portal>
   );
 }

--- a/src/components/ui/Portal.tsx
+++ b/src/components/ui/Portal.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+// Renders children into document.body so that fixed-positioned overlays escape
+// any ancestor with a transform/filter/backdrop-blur (which would otherwise
+// become the containing block and trap the overlay). SSR-safe: renders nothing
+// on the server, then portals once mounted on the client.
+export default function Portal({ children }: { children: React.ReactNode }) {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+    return () => setMounted(false);
+  }, []);
+  if (!mounted) return null;
+  return createPortal(children, document.body);
+}


### PR DESCRIPTION
Modals were trapped by ancestors with transform/filter/backdrop-blur (framer-motion, header/hero blur), so their fixed overlay was confined and scrolled with the page. Render modals in a React portal to document.body (SSR-safe) so the fixed overlay is viewport-relative, add body scroll lock while open, and allow tall panels to scroll internally. Applies to the shared Modal, SignInModal and LinkGameModal.