### PR TITLE
feat(social): localize notifications and add friend chat shortcut

### DIFF
--- a/src/app/(main)/friends/page.tsx
+++ b/src/app/(main)/friends/page.tsx
@@ -2,8 +2,9 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
-import { Users2, Check, X, UserMinus } from 'lucide-react';
+import { Users2, Check, X, UserMinus, MessageSquare } from 'lucide-react';
 import { api, avatarSrc } from '@/lib/api';
 import { useT } from '@/lib/i18n';
 import { Button, PageHeader, EmptyState, LoadingSpinner, Tabs, Avatar } from '@/components/ui';
@@ -14,6 +15,7 @@ import toast from 'react-hot-toast';
 
 export default function FriendsPage() {
   const t = useT();
+  const router = useRouter();
   const [tab, setTab] = useState<'friends' | 'requests'>('friends');
   const [friends, setFriends] = useState<any[]>([]);
   const [requests, setRequests] = useState<any[]>([]);
@@ -120,14 +122,27 @@ export default function FriendsPage() {
                     {u.gameRank || u.country}
                   </div>
                 </Link>
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  disabled={busy === u.id}
-                  onClick={() => setConfirm({ kind: 'remove', user: u })}
-                >
-                  <UserMinus size={14} /> {t('friends.remove')}
-                </Button>
+                <div className="flex shrink-0 items-center gap-2">
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() =>
+                      router.push(
+                        `/messages?to=${u.id}&name=${encodeURIComponent(u.displayName || u.username)}`,
+                      )
+                    }
+                  >
+                    <MessageSquare size={14} /> {t('friends.chat')}
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    disabled={busy === u.id}
+                    onClick={() => setConfirm({ kind: 'remove', user: u })}
+                  >
+                    <UserMinus size={14} /> {t('friends.remove')}
+                  </Button>
+                </div>
               </motion.div>
             ))}
           </div>

--- a/src/app/(main)/messages/page.tsx
+++ b/src/app/(main)/messages/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Suspense } from 'react';
 import { MessageSquare } from 'lucide-react';
 import { useT } from '@/lib/i18n';
 import { PageHeader } from '@/components/ui';
@@ -10,7 +11,9 @@ export default function MessagesPage() {
   return (
     <div className="space-y-6">
       <PageHeader icon={<MessageSquare size={28} />} title={t('messages.title')} variant="cyan" />
-      <MessagesInbox />
+      <Suspense fallback={null}>
+        <MessagesInbox />
+      </Suspense>
     </div>
   );
 }

--- a/src/components/common/NotificationBell.tsx
+++ b/src/components/common/NotificationBell.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Bell } from 'lucide-react';
 import { api } from '@/lib/api';
-import { useT } from '@/lib/i18n';
+import { useT, notifContent } from '@/lib/i18n';
 import { getSocket, usePresence } from '@/lib/realtime';
 
 export default function NotificationBell() {
@@ -112,25 +112,28 @@ export default function NotificationBell() {
             <div className="px-4 py-8 text-center text-sm text-gray-500">{t('notif.none')}</div>
           ) : (
             <ul>
-              {items.map((n) => (
-                <li key={n.id}>
-                  <button
-                    type="button"
-                    onClick={() => openItem(n)}
-                    className={`w-full text-left px-4 py-3 border-b border-gaming-border/50 hover:bg-gaming-surface transition-colors ${
-                      !n.read ? 'bg-neon-blue/5' : ''
-                    }`}
-                  >
-                    <div className="flex items-start gap-2">
-                      {!n.read && <span className="mt-1.5 w-2 h-2 rounded-full bg-neon-blue shrink-0" />}
-                      <div className="min-w-0">
-                        <p className="text-sm font-medium text-white">{n.title}</p>
-                        {n.message && <p className="text-xs text-gray-400 mt-0.5">{n.message}</p>}
+              {items.map((n) => {
+                const { title, message } = notifContent(n, t);
+                return (
+                  <li key={n.id}>
+                    <button
+                      type="button"
+                      onClick={() => openItem(n)}
+                      className={`w-full text-left px-4 py-3 border-b border-gaming-border/50 hover:bg-gaming-surface transition-colors ${
+                        !n.read ? 'bg-neon-blue/5' : ''
+                      }`}
+                    >
+                      <div className="flex items-start gap-2">
+                        {!n.read && <span className="mt-1.5 w-2 h-2 rounded-full bg-neon-blue shrink-0" />}
+                        <div className="min-w-0">
+                          <p className="text-sm font-medium text-white">{title}</p>
+                          {message && <p className="text-xs text-gray-400 mt-0.5">{message}</p>}
+                        </div>
                       </div>
-                    </div>
-                  </button>
-                </li>
-              ))}
+                    </button>
+                  </li>
+                );
+              })}
             </ul>
           )}
         </div>

--- a/src/components/layout/NotificationDropdown.tsx
+++ b/src/components/layout/NotificationDropdown.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { api } from '@/lib/api';
-import { useT } from '@/lib/i18n';
+import { useT, notifContent } from '@/lib/i18n';
 import { timeAgo } from '@/lib/helpers';
 import { getSocket, usePresence } from '@/lib/realtime';
 
@@ -157,6 +157,7 @@ export default function NotificationDropdown() {
             <ul className="flex h-auto flex-col overflow-y-auto">
               {items.map((n) => {
                 const time = timeAgo(n.createdAt);
+                const { title, message } = notifContent(n, t);
                 return (
                   <li key={n.id}>
                     <button
@@ -167,8 +168,8 @@ export default function NotificationDropdown() {
                       }`}
                     >
                       <p className="text-sm text-body dark:text-bodydark">
-                        <span className="text-black dark:text-white">{n.title}</span>
-                        {n.message ? ` ${n.message}` : ''}
+                        <span className="text-black dark:text-white">{title}</span>
+                        {message ? ` ${message}` : ''}
                       </p>
                       {time && <p className="text-xs">{time}</p>}
                     </button>

--- a/src/components/messages/MessagesInbox.tsx
+++ b/src/components/messages/MessagesInbox.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
 import { ArrowLeft, Send, MessageSquare, Shield, Search } from 'lucide-react';
 import { api, avatarSrc } from '@/lib/api';
 import { useT } from '@/lib/i18n';
@@ -18,13 +19,18 @@ const isStaff = (role?: string): boolean =>
 
 export default function MessagesInbox() {
   const t = useT();
+  const searchParams = useSearchParams();
+  const router = useRouter();
   const [threads, setThreads] = useState<any[]>([]);
   const [activeId, setActiveId] = useState<string | null>(null);
   const [thread, setThread] = useState<any | null>(null);
+  // Draft conversation opened from a deep link (?to=) with no existing thread.
+  const [draftPeer, setDraftPeer] = useState<{ id: string; name: string } | null>(null);
   const [loading, setLoading] = useState(true);
   const [sending, setSending] = useState(false);
   const [text, setText] = useState('');
   const [search, setSearch] = useState('');
+  const handledToRef = useRef(false);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const myId = useAuthStore((s: any) => s.user?.id);
   const online = usePresence((s) => s.online);
@@ -73,9 +79,47 @@ export default function MessagesInbox() {
     [scrollToBottom, t],
   );
 
+  // Deep link: /messages?to=<userId>&name=<name>. Open the existing thread with
+  // that user, or start a draft conversation when none exists yet.
+  useEffect(() => {
+    const to = searchParams.get('to');
+    if (!to || loading || handledToRef.current) return;
+    handledToRef.current = true;
+    const existing = threads.find((th) => th.other?.id === to);
+    if (existing) {
+      openThread(existing.id);
+    } else {
+      setDraftPeer({ id: to, name: searchParams.get('name') || '' });
+      setActiveId(null);
+      setThread(null);
+    }
+    router.replace('/messages');
+  }, [searchParams, loading, threads, openThread, router]);
+
   const send = useCallback(async () => {
     const body = text.trim();
-    if (!body || !activeId || sending) return;
+    if (!body || sending) return;
+
+    // First message of a draft conversation: create the thread.
+    if (!activeId && draftPeer) {
+      setSending(true);
+      try {
+        const created: any = await api.messages.startThread({ userId: draftPeer.id, body });
+        setThread(created);
+        setActiveId(created?.id ?? null);
+        setDraftPeer(null);
+        setText('');
+        scrollToBottom();
+        loadThreads();
+      } catch (e: any) {
+        toast.error(e?.message || t('common.error'));
+      } finally {
+        setSending(false);
+      }
+      return;
+    }
+
+    if (!activeId) return;
     setSending(true);
     try {
       const updated: any = await api.messages.reply(activeId, body);
@@ -88,7 +132,7 @@ export default function MessagesInbox() {
     } finally {
       setSending(false);
     }
-  }, [text, activeId, sending, scrollToBottom, loadThreads, t]);
+  }, [text, activeId, draftPeer, sending, scrollToBottom, loadThreads, t]);
 
   // Live message reception (WebSocket).
   useEffect(() => {
@@ -137,6 +181,10 @@ export default function MessagesInbox() {
   }, [connected, myId, scrollToBottom, loadThreads]);
 
   const other = thread?.other;
+  // Peer shown in the conversation header: the thread's peer, or the draft target.
+  const headerPeer = other ?? (draftPeer ? { id: draftPeer.id, displayName: draftPeer.name } : null);
+  // Right panel is open for an active thread or a draft conversation.
+  const panelOpen = !!activeId || !!draftPeer;
 
   // Client-side filter of the thread list (search box).
   const q = search.trim().toLowerCase();
@@ -164,12 +212,12 @@ export default function MessagesInbox() {
         {/* Left column: conversation list */}
         <div
           className={`${
-            activeId ? 'hidden' : 'flex'
+            panelOpen ? 'hidden' : 'flex'
           } h-full flex-col xl:flex xl:w-1/4`}
         >
           <div className="sticky border-b border-stroke px-6 py-7.5 dark:border-strokedark">
             <h3 className="text-lg font-medium text-black dark:text-white 2xl:text-xl">
-              Conversations
+              {t('messages.conversations')}
               <span className="rounded-md border-[.5px] border-stroke bg-gray-2 px-2 py-0.5 text-base font-medium text-black dark:border-strokedark dark:bg-boxdark-2 dark:text-white 2xl:ml-4">
                 {threads.length}
               </span>
@@ -185,7 +233,7 @@ export default function MessagesInbox() {
                   value={search}
                   onChange={(e) => setSearch(e.target.value)}
                   className="w-full rounded border border-stroke bg-gray-2 py-2.5 pl-5 pr-10 text-sm text-black outline-none focus:border-primary dark:border-strokedark dark:bg-boxdark-2 dark:text-white"
-                  placeholder="Rechercher..."
+                  placeholder={t('messages.search')}
                 />
                 <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-bodydark2">
                   <Search size={18} />
@@ -268,10 +316,10 @@ export default function MessagesInbox() {
         {/* Right column: active conversation */}
         <div
           className={`${
-            activeId ? 'flex' : 'hidden'
+            panelOpen ? 'flex' : 'hidden'
           } h-full flex-col border-l border-stroke dark:border-strokedark xl:flex xl:w-3/4`}
         >
-          {!activeId ? (
+          {!panelOpen ? (
             <div className="flex flex-1 flex-col items-center justify-center gap-2 text-sm text-bodydark2">
               <MessageSquare size={32} className="opacity-50" />
               {t('messages.empty')}
@@ -286,6 +334,7 @@ export default function MessagesInbox() {
                     onClick={() => {
                       setActiveId(null);
                       setThread(null);
+                      setDraftPeer(null);
                     }}
                     className="mr-3 rounded-md p-1.5 text-body hover:bg-gray-2 dark:text-bodydark dark:hover:bg-meta-4 xl:hidden"
                     aria-label={t('messages.title')}
@@ -293,29 +342,29 @@ export default function MessagesInbox() {
                     <ArrowLeft size={18} />
                   </button>
                   <div className="relative mr-4.5 h-13 w-13 shrink-0 rounded-full">
-                    {other?.avatar ? (
+                    {headerPeer?.avatar ? (
                       // eslint-disable-next-line @next/next/no-img-element
                       <img
-                        src={avatarSrc(other.avatar, 64)}
-                        alt={nameOf(other)}
+                        src={avatarSrc(headerPeer.avatar, 64)}
+                        alt={nameOf(headerPeer)}
                         referrerPolicy="no-referrer"
                         className="h-full w-full rounded-full object-cover"
                       />
                     ) : (
                       <div className="flex h-full w-full items-center justify-center rounded-full bg-primary text-base font-bold text-white">
-                        {initialOf(other)}
+                        {initialOf(headerPeer)}
                       </div>
                     )}
-                    {other?.id && online.has(other.id) && (
+                    {headerPeer?.id && online.has(headerPeer.id) && (
                       <span className="absolute bottom-0 right-0 block h-3.5 w-3.5 rounded-full border-2 border-white bg-success dark:border-boxdark" />
                     )}
                   </div>
                   <div className="min-w-0">
                     <h5 className="truncate font-medium text-black dark:text-white">
-                      {nameOf(other) || thread?.subject || ''}
+                      {nameOf(headerPeer) || thread?.subject || ''}
                     </h5>
                     <p className="text-sm font-medium text-body dark:text-bodydark">
-                      Répondre au message
+                      {t('messages.replyTo')}
                     </p>
                   </div>
                 </div>
@@ -327,9 +376,16 @@ export default function MessagesInbox() {
                 className="no-scrollbar max-h-full flex-1 space-y-3.5 overflow-auto px-6 py-7.5"
               >
                 {!thread ? (
-                  <div className="flex items-center justify-center py-10">
-                    <div className="h-8 w-8 animate-spin rounded-full border-2 border-stroke border-t-primary dark:border-strokedark dark:border-t-primary" />
-                  </div>
+                  draftPeer ? (
+                    <div className="flex h-full flex-col items-center justify-center gap-2 text-center text-sm text-bodydark2">
+                      <MessageSquare size={28} className="opacity-50" />
+                      {t('messages.startWith', { name: draftPeer.name })}
+                    </div>
+                  ) : (
+                    <div className="flex items-center justify-center py-10">
+                      <div className="h-8 w-8 animate-spin rounded-full border-2 border-stroke border-t-primary dark:border-strokedark dark:border-t-primary" />
+                    </div>
+                  )
                 ) : (
                   (thread.messages || []).map((m: any) =>
                     m.mine ? (

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -85,6 +85,7 @@ export const translations: Record<string, Dict> = {
     'friends.sent': 'Demande d’ami envoyée.',
     'friends.added': 'Ami ajouté.',
     'friends.removed': 'Retiré.',
+    'friends.chat': 'Discuter',
     'teams.manageRoster': 'Gérer l’effectif',
     'teams.planMatch': 'Planifier un match',
     'teams.opponent': 'Adversaire',
@@ -122,6 +123,24 @@ export const translations: Record<string, Dict> = {
     'notif.none': 'Aucune notification.',
     'notif.markAllRead': 'Tout marquer comme lu',
     'notif.viewAll': 'Voir toutes les notifications',
+    'notif.friend_request.title': 'Nouvelle demande d’ami',
+    'notif.friend_request.message': '{who} veut vous ajouter en ami.',
+    'notif.friend_accept.title': 'Demande acceptée',
+    'notif.friend_accept.message': '{who} a accepté votre demande d’ami.',
+    'notif.recruitment_application.title': 'Nouvelle candidature',
+    'notif.recruitment_application.message': '{who} a postulé à votre recrutement.',
+    'notif.recruitment_decision.accepted.title': 'Candidature acceptée',
+    'notif.recruitment_decision.rejected.title': 'Candidature refusée',
+    'notif.recruitment_decision.message': 'Équipe « {team} ».',
+    'notif.team_request.title': 'Nouvelle demande d’équipe',
+    'notif.team_request.message': '{who} propose l’équipe « {team} ».',
+    'notif.request_decision.in_review.title': 'Votre demande est en cours d’examen',
+    'notif.request_decision.approved.title': 'Votre demande a été acceptée',
+    'notif.request_decision.rejected.title': 'Votre demande a été refusée',
+    'notif.request_decision.pending.title': 'Votre demande est en attente',
+    'notif.request_decision.default.title': 'Mise à jour de votre demande',
+    'notif.request_decision.message': 'Équipe « {team} ».',
+    'notif.message.title': 'Nouveau message',
     'header.messages': 'Messages',
     'header.viewAllMessages': 'Voir tous les messages',
     'requests.title': 'Demandes d’équipe',
@@ -153,6 +172,10 @@ export const translations: Record<string, Dict> = {
     'messages.subject': 'Sujet (optionnel)',
     'messages.body': 'Message',
     'messages.sent': 'Message envoyé.',
+    'messages.conversations': 'Conversations',
+    'messages.search': 'Rechercher…',
+    'messages.replyTo': 'Répondre au message',
+    'messages.startWith': 'Écris ton premier message à {name}.',
     'common.error': 'Une erreur est survenue.',
     'admin.seasons.title': 'Saisons',
     'admin.matches.title': 'Matchs',
@@ -704,6 +727,7 @@ export const translations: Record<string, Dict> = {
     'friends.sent': 'Friend request sent.',
     'friends.added': 'Friend added.',
     'friends.removed': 'Removed.',
+    'friends.chat': 'Chat',
     'teams.manageRoster': 'Manage roster',
     'teams.planMatch': 'Plan a match',
     'teams.opponent': 'Opponent',
@@ -741,6 +765,24 @@ export const translations: Record<string, Dict> = {
     'notif.none': 'No notification.',
     'notif.markAllRead': 'Mark all as read',
     'notif.viewAll': 'View all notifications',
+    'notif.friend_request.title': 'New friend request',
+    'notif.friend_request.message': '{who} wants to add you as a friend.',
+    'notif.friend_accept.title': 'Request accepted',
+    'notif.friend_accept.message': '{who} accepted your friend request.',
+    'notif.recruitment_application.title': 'New application',
+    'notif.recruitment_application.message': '{who} applied to your recruitment.',
+    'notif.recruitment_decision.accepted.title': 'Application accepted',
+    'notif.recruitment_decision.rejected.title': 'Application declined',
+    'notif.recruitment_decision.message': 'Team “{team}”.',
+    'notif.team_request.title': 'New team request',
+    'notif.team_request.message': '{who} proposes the team “{team}”.',
+    'notif.request_decision.in_review.title': 'Your request is under review',
+    'notif.request_decision.approved.title': 'Your request was approved',
+    'notif.request_decision.rejected.title': 'Your request was declined',
+    'notif.request_decision.pending.title': 'Your request is pending',
+    'notif.request_decision.default.title': 'Update on your request',
+    'notif.request_decision.message': 'Team “{team}”.',
+    'notif.message.title': 'New message',
     'header.messages': 'Messages',
     'header.viewAllMessages': 'View all messages',
     'requests.title': 'Team requests',
@@ -772,6 +814,10 @@ export const translations: Record<string, Dict> = {
     'messages.subject': 'Subject (optional)',
     'messages.body': 'Message',
     'messages.sent': 'Message sent.',
+    'messages.conversations': 'Conversations',
+    'messages.search': 'Search…',
+    'messages.replyTo': 'Reply to the message',
+    'messages.startWith': 'Write your first message to {name}.',
     'common.error': 'Something went wrong.',
     'admin.seasons.title': 'Seasons',
     'admin.matches.title': 'Matches',
@@ -1295,7 +1341,70 @@ export const translations: Record<string, Dict> = {
 export function useT() {
   const lang = useLangStore((s: any) => s.lang);
   return useCallback(
-    (key: string): string => translations[lang]?.[key] ?? translations.fr[key] ?? key,
+    (key: string, params?: Record<string, string | number>): string => {
+      const raw = translations[lang]?.[key] ?? translations.fr[key] ?? key;
+      if (!params) return raw;
+      return raw.replace(/\{(\w+)\}/g, (_, k) =>
+        params[k] != null ? String(params[k]) : `{${k}}`,
+      );
+    },
     [lang],
   );
+}
+
+type TFn = (key: string, params?: Record<string, string | number>) => string;
+
+/**
+ * Build a localized title/message for a notification from its `type` + `data`.
+ * The server stores French title/message as a fallback: legacy notifications
+ * (no `data`) and unknown types render that stored text verbatim.
+ */
+export function notifContent(n: any, t: TFn): { title: string; message: string } {
+  const type = n?.type;
+  const d = n?.data || {};
+
+  // Title is enough to localize a "new message" notification; the body stays
+  // as-is since it is user content.
+  if (type === 'message') {
+    return { title: t('notif.message.title'), message: n?.message ?? '' };
+  }
+
+  // Without structured params we cannot rebuild the sentence — keep the stored
+  // (already French) text.
+  if (!n?.data) return { title: n?.title ?? '', message: n?.message ?? '' };
+
+  switch (type) {
+    case 'friend_request':
+    case 'friend_accept':
+    case 'recruitment_application':
+      return {
+        title: t(`notif.${type}.title`),
+        message: t(`notif.${type}.message`, { who: d.who ?? '' }),
+      };
+    case 'team_request':
+      return {
+        title: t('notif.team_request.title'),
+        message: t('notif.team_request.message', {
+          who: d.who ?? '',
+          team: d.teamName ?? '',
+        }),
+      };
+    case 'recruitment_decision':
+      return {
+        title: t(
+          `notif.recruitment_decision.${d.status === 'accepted' ? 'accepted' : 'rejected'}.title`,
+        ),
+        message: t('notif.recruitment_decision.message', { team: d.teamName ?? '' }),
+      };
+    case 'request_decision': {
+      const known = ['in_review', 'approved', 'rejected', 'pending'];
+      const status = known.includes(d.status) ? d.status : 'default';
+      return {
+        title: t(`notif.request_decision.${status}.title`),
+        message: t('notif.request_decision.message', { team: d.teamName ?? '' }),
+      };
+    }
+    default:
+      return { title: n?.title ?? '', message: n?.message ?? '' };
+  }
 }


### PR DESCRIPTION
## Notifications internationalisées

Les notifications étaient générées en français en dur côté serveur, donc jamais traduites. Le client construit désormais leur texte à partir du `type` et des données structurées :

- `useT()` gère l'interpolation (`{who}`, `{team}`…).
- Nouveau helper `notifContent(n, t)` : titre et message localisés par type, avec repli sur le texte stocké pour les anciennes notifications et les types inconnus.
- Appliqué dans `NotificationDropdown` et `NotificationBell`.
- Clés ajoutées en français et en anglais pour tous les types (ami, recrutement, équipe, message).

## Raccourci « Discuter » avec un ami

- Bouton **Discuter** sur chaque carte d'ami, qui mène à `/messages?to=<id>&name=<name>`.
- `MessagesInbox` gère le lien profond : ouvre la conversation existante avec ce joueur, ou compose une nouvelle conversation (création du fil au premier envoi).
- Textes en dur de la messagerie passés à l'i18n (Conversations, recherche, sous-titre, invite de nouvelle conversation).
