### PR TITLE
feat(roles): official role SVGs everywhere + settings cleanup

### DIFF
--- a/src/app/(main)/heroes/page.tsx
+++ b/src/app/(main)/heroes/page.tsx
@@ -6,6 +6,7 @@ import { Search, Swords } from 'lucide-react';
 import { api, mlbbImg } from '@/lib/api';
 import { PageHeader, SectionCard, Button, EmptyState, LoadingSpinner } from '@/components/ui';
 import HeroDetailModal from '@/components/game/HeroDetailModal';
+import RoleIcon from '@/components/game/RoleIcon';
 import { useT } from '@/lib/i18n';
 
 const ROLES: Array<{ key: string; labelKey: string }> = [
@@ -70,7 +71,9 @@ export default function HeroesPage() {
               size="sm"
               variant={role === r.key ? 'primary' : 'outline'}
               onClick={() => setRole(r.key)}
+              className="gap-1.5"
             >
+              {r.key !== 'all' && <RoleIcon role={r.key} size={15} />}
               {t(r.labelKey)}
             </Button>
           ))}
@@ -107,7 +110,11 @@ export default function HeroesPage() {
               </div>
               <div className="p-2">
                 <p className="text-xs font-semibold text-black dark:text-white truncate">{h.name}</p>
-                <p className="text-[10px] text-body dark:text-bodydark truncate">{(h.roles || []).join(' · ')}</p>
+                <div className="mt-0.5 flex items-center gap-1">
+                  {(h.roles || []).slice(0, 3).map((r: string) => (
+                    <RoleIcon key={r} role={r} size={13} />
+                  ))}
+                </div>
               </div>
             </motion.button>
           ))}

--- a/src/app/(main)/settings/page.tsx
+++ b/src/app/(main)/settings/page.tsx
@@ -5,14 +5,13 @@ import { useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
 import {
   Settings as SettingsIcon, User, Bell, Shield, Palette,
-  Trash2, Save, Moon, Sun, Eye, EyeOff,
+  Trash2, Save, Moon, Sun,
 } from 'lucide-react';
-import { Card, Button, Input, Textarea, Select, Badge, Tabs, PageHeader, SectionCard } from '@/components/ui';
+import { Card, Button, Input, Textarea, Badge, Tabs, PageHeader, SectionCard } from '@/components/ui';
 import ConfirmModal from '@/components/ui/ConfirmModal';
 import { useThemeStore, useAuthStore } from '@/store/useStore';
 import { api, setToken } from '@/lib/api';
 import { isPushSupported, isPushEnabled, enablePush, disablePush } from '@/lib/push';
-import { MLBB_RANKS, MLBB_ROLES } from '@/lib/constants';
 import toast from 'react-hot-toast';
 import { useT } from '@/lib/i18n';
 
@@ -29,16 +28,14 @@ export default function Settings() {
   const t = useT();
 
   const [activeTab, setActiveTab] = useState('profile');
-  const [showPassword, setShowPassword] = useState(false);
   const [showDelete, setShowDelete] = useState(false);
   const [saving, setSaving] = useState<string | null>(null);
 
   const [profile, setProfile] = useState({
-    username: '', email: '', bio: '', rank: 'warrior', role: 'fighter', country: '', city: '',
+    username: '', email: '', bio: '', country: '', city: '',
   });
   const [notifications, setNotifications] = useState<any>(DEFAULT_NOTIFS);
   const [privacy, setPrivacy] = useState<any>(DEFAULT_PRIVACY);
-  const [pwd, setPwd] = useState({ current: '', next: '', confirm: '' });
   const [pushSupported, setPushSupported] = useState(false);
   const [pushOn, setPushOn] = useState(false);
   const [pushBusy, setPushBusy] = useState(false);
@@ -81,8 +78,6 @@ export default function Settings() {
       username: userProfile.username || '',
       email: userProfile.email || '',
       bio: userProfile.bio || '',
-      rank: userProfile.rank || 'warrior',
-      role: userProfile.role || 'fighter',
       country: userProfile.country || '',
       city: userProfile.city || '',
     });
@@ -112,31 +107,10 @@ export default function Settings() {
       username: profile.username,
       bio: profile.bio,
       city: profile.city,
-      rank: profile.rank,
-      role: profile.role,
       country: profile.country,
     });
   const saveNotifications = () => persist('notifications', { notifPrefs: notifications });
   const savePrivacy = () => persist('privacy', { privacy });
-
-  const changePassword = async () => {
-    if (!pwd.current || !pwd.next) return toast.error(t('settings.pwdRequired'));
-    if (pwd.next !== pwd.confirm) return toast.error(t('settings.pwdMismatch'));
-    setSaving('password');
-    try {
-      await api.auth.changePassword({
-        email: profile.email,
-        currentPassword: pwd.current,
-        newPassword: pwd.next,
-      });
-      setPwd({ current: '', next: '', confirm: '' });
-      toast.success(t('settings.pwdChanged'));
-    } catch (e: any) {
-      toast.error(e?.message || t('common.error'));
-    } finally {
-      setSaving(null);
-    }
-  };
 
   const deleteAccount = async () => {
     setSaving('delete');
@@ -203,71 +177,6 @@ export default function Settings() {
                 onChange={(e: any) => setProfile({ ...profile, bio: e.target.value })}
                 rows={3}
               />
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <Select
-                  label={t('settings.mlbbRank')}
-                  value={profile.rank}
-                  onChange={(e: any) => setProfile({ ...profile, rank: e.target.value })}
-                >
-                  {MLBB_RANKS.map((r) => (
-                    <option key={r.id} value={r.id}>{r.name}</option>
-                  ))}
-                </Select>
-                <Select
-                  label={t('settings.mainRole')}
-                  value={profile.role}
-                  onChange={(e: any) => setProfile({ ...profile, role: e.target.value })}
-                >
-                  {MLBB_ROLES.map((r) => (
-                    <option key={r.id} value={r.id}>{r.icon} {r.name}</option>
-                  ))}
-                </Select>
-              </div>
-            </div>
-          </Card>
-
-          <Card>
-            <h3 className="font-bold text-lg mb-4 text-black dark:text-white">
-              {t('settings.changePassword')}
-            </h3>
-            <div className="space-y-4">
-              <div className="relative">
-                <Input
-                  label={t('settings.currentPassword')}
-                  type={showPassword ? 'text' : 'password'}
-                  placeholder="••••••••"
-                  value={pwd.current}
-                  onChange={(e: any) => setPwd({ ...pwd, current: e.target.value })}
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowPassword(!showPassword)}
-                  className="absolute right-3 top-9 text-bodydark2 hover:text-body dark:hover:text-bodydark"
-                >
-                  {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
-                </button>
-              </div>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <Input
-                  label={t('settings.newPassword')}
-                  type="password"
-                  placeholder="••••••••"
-                  value={pwd.next}
-                  onChange={(e: any) => setPwd({ ...pwd, next: e.target.value })}
-                />
-                <Input
-                  label={t('settings.confirmPassword')}
-                  type="password"
-                  placeholder="••••••••"
-                  value={pwd.confirm}
-                  onChange={(e: any) => setPwd({ ...pwd, confirm: e.target.value })}
-                />
-              </div>
-              <div className="flex justify-end">
-                <Button variant="outline" onClick={changePassword} loading={saving === 'password'}>
-                  {t('settings.changePassword')}
-                </Button>
-              </div>
             </div>
           </Card>
 

--- a/src/app/admin/catalog/page.tsx
+++ b/src/app/admin/catalog/page.tsx
@@ -15,6 +15,7 @@ import {
   LoadingSpinner,
 } from '@/components/ui';
 import Modal from '@/components/ui/Modal';
+import RoleIcon from '@/components/game/RoleIcon';
 import toast from 'react-hot-toast';
 
 // Shape of a lane as returned by GraphQL / REST.
@@ -44,6 +45,7 @@ type LaneForm = {
 export default function AdminCatalogPage() {
   const t = useT();
   const [lanes, setLanes] = useState<Lane[]>([]);
+  const [roles, setRoles] = useState<any[]>([]);
   const [heroCount, setHeroCount] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -55,12 +57,14 @@ export default function AdminCatalogPage() {
   // Load lanes + hero count via GraphQL.
   const load = async () => {
     try {
-      const [ls, hs] = await Promise.all([
+      const [ls, hs, rs] = await Promise.all([
         api.catalog.lanes(),
         api.catalog.heroes(),
+        api.catalog.roles(),
       ]);
       setLanes(Array.isArray(ls) ? ls : []);
       setHeroCount(Array.isArray(hs) ? hs.length : 0);
+      setRoles(Array.isArray(rs) ? rs : []);
     } catch (e: any) {
       toast.error(e?.message || 'Erreur de chargement du catalogue');
     }
@@ -147,6 +151,26 @@ export default function AdminCatalogPage() {
         <LoadingSpinner size="lg" className="py-24" />
       ) : (
         <>
+          {/* Hero roles section (read-only reference) */}
+          <SectionCard>
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-lg font-semibold text-black dark:text-white">Rôles</h2>
+              <Badge variant="purple" size="sm">{roles.length}</Badge>
+            </div>
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+              {roles.map((r) => (
+                <div
+                  key={r.key}
+                  className="flex flex-col items-center gap-2 rounded-lg border border-stroke bg-gray-2 p-3 text-center dark:border-strokedark dark:bg-meta-4"
+                >
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img src={r.icon} alt={r.name} referrerPolicy="no-referrer" className="h-10 w-10 object-contain" />
+                  <span className="text-sm font-medium text-black dark:text-white">{r.name}</span>
+                </div>
+              ))}
+            </div>
+          </SectionCard>
+
           {/* Lanes section */}
           <SectionCard>
             <div className="flex items-center justify-between mb-4">
@@ -170,18 +194,12 @@ export default function AdminCatalogPage() {
                     <div className="w-12 h-12 rounded-lg bg-gray-2 border border-stroke shrink-0 dark:bg-meta-4 dark:border-strokedark" />
                   )}
                   <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-2">
-                      <p className="text-sm font-semibold text-black dark:text-white truncate">{lane.name}</p>
-                      {lane.shortName && (
-                        <Badge variant="default" size="sm">
-                          {lane.shortName}
-                        </Badge>
-                      )}
-                    </div>
+                    <p className="text-sm font-semibold text-black dark:text-white truncate">{lane.name}</p>
                     {lane.compatibleClasses?.length > 0 && (
                       <div className="flex flex-wrap gap-1 mt-1.5">
                         {lane.compatibleClasses.map((c) => (
-                          <Badge key={c} variant="neon" size="sm">
+                          <Badge key={c} variant="neon" size="sm" className="gap-1">
+                            <RoleIcon role={c} size={13} />
                             {c}
                           </Badge>
                         ))}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -121,9 +121,6 @@ export const api = {
   auth: {
     me: () => request('/auth/me'),
 
-    changePassword: (data: { email: string; currentPassword: string; newPassword: string }) =>
-      request('/auth/change-password', { method: 'POST', body: data, auth: false }),
-
     adminLogin: (data: { username: string; password: string }) =>
       request('/auth/admin/login', { method: 'POST', body: data, auth: false }),
 
@@ -242,6 +239,10 @@ export const api = {
       gql<{ lanes: any[] }>(
         `{ lanes { id key name shortName description icon color compatibleClasses sort } }`,
       ).then((d) => d.lanes),
+    roles: () =>
+      gql<{ heroRoles: any[] }>(
+        `{ heroRoles { id key name icon sort } }`,
+      ).then((d) => d.heroRoles),
     heroes: (role?: string) =>
       gql<{ heroes: any[] }>(
         `query($role: String) { heroes(role: $role) { id name role } }`,

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -11,12 +11,12 @@ export const MLBB_RANKS = [
 ];
 
 export const MLBB_ROLE_ICONS: Record<string, string> = {
-  tank: 'https://akmweb.youngjoygame.com/web/gms/image/a3dbb075b4d8186c29f02f7d47da236a.svg',
-  fighter: 'https://akmweb.youngjoygame.com/web/gms/image/6a246099f7eb83a8856306d8b4c84fc2.svg',
-  assassin: 'https://akmweb.youngjoygame.com/web/gms/image/de611167c7310681135f0b4198137bfa.svg',
-  mage: 'https://akmweb.youngjoygame.com/web/gms/image/facab1eacb218d767b5acb80304bfafd.svg',
-  marksman: 'https://akmweb.youngjoygame.com/web/gms/image/91f817c656908a83c2e24eecb3b70986.svg',
-  support: 'https://akmweb.youngjoygame.com/web/gms/image/a3dbb075b4d8186c29f02f7d47da236a.svg',
+  tank: 'https://akmweb.youngjoygame.com/web/gms/image/60638c59536d9505c9c731af13f7fdfd.png',
+  support: 'https://akmweb.youngjoygame.com/web/gms/image/1e4609b25a4cd63ee5a13015d4058159.png',
+  fighter: 'https://akmweb.youngjoygame.com/web/gms/image/629e282165d4b63deceaf350426ea440.png',
+  assassin: 'https://akmweb.youngjoygame.com/web/gms/image/d0b8b65a47fc43dc7bb2bac447072fd2.png',
+  mage: 'https://akmweb.youngjoygame.com/web/gms/image/1c6985dd0caec2028ccb6d1b8ca95e0f.png',
+  marksman: 'https://akmweb.youngjoygame.com/web/gms/image/025c69a764924f4bac526a2662f1a0b9.png',
 };
 
 export const MLBB_ARROW_LEFT = 'https://akmweb.youngjoygame.com/web/gms/image/b5e4de459ce7ea23df0ae3c69b5e4807.svg';


### PR DESCRIPTION
## Icônes SVG des rôles + nettoyage réglages

### Rôles de héros en SVG (fini les émojis)
- Mise à jour de `MLBB_ROLE_ICONS` avec les 6 icônes officielles Moonton (tank/fighter/assassin/mage/marksman/support). Comme `RoleIcon` s'appuie dessus, les vraies icônes apparaissent **partout** où un rôle est cité.
- **Page héros** : icône SVG sur les filtres de rôle et sur les cartes de héros.
- **Admin catalog** : nouvelle section « Rôles » (lue depuis la table `HeroRole`), et icône SVG sur les classes compatibles des lanes.

### Nettoyages
- **Admin catalog** : suppression du petit badge redondant qui répétait le nom court de la lane (Gold/Roam/Mid…).
- **Réglages profil** : suppression de « MLBB Rank » et « Rôle principal » (ces données viennent du compte de jeu, l'utilisateur ne les définit pas) et de toute la section « Changer le mot de passe » (connexion via Google / compte de jeu uniquement ; le mot de passe admin se gère côté base). Retrait de la méthode API `changePassword` associée.
